### PR TITLE
Add entity-aware ASR evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 모든 중요한 변경 사항은 이 파일에 기록됩니다.
 
 
-## [0.0.0.12] - 2026-07-12
+## [0.0.0.12] - 2026-07-16
 
 ---
 
@@ -15,6 +15,10 @@
   - micro/macro CER·WER, 편집 횟수 합계, 완전 일치 문장 수, 문장 오류율 제공.
 - 키워드 실제 언급 횟수와 false positive/false negative를 집계하는 evaluate_keywords 추가.
   - 선택적으로 ORG, PRODUCT와 같은 라벨별 precision, recall, F1 제공.
+- 참조 개체명 span의 문자 오류율과 개체명 언급 F1을 함께 제공하는 evaluate_entities 추가.
+  - Entity CER micro/macro, 개체명·라벨별 편집 횟수, 누락·추가·오인식 목록 제공.
+  - 사용자가 명시한 aliases만 동일 개체의 허용 전사형으로 처리하며 퍼지 매칭은 적용하지 않음.
+  - NE-WER, NEER, Spoken NER 관련 논문과 한국어 적용 기준을 README와 사용자 매뉴얼에 명시.
 - 문자·단어 단위 정렬과 치환/삭제/삽입 빈도를 보여주는 explain_errors 추가.
 - NFC, NFD, NFKC, NFKD 유니코드 정규화를 선택할 수 있는 unicode_normalization 옵션 추가.
 
@@ -35,10 +39,13 @@
 - get_cer, get_wer, get_crr의 기본 계산 결과와 기존 반환 키를 그대로 유지.
 - calculate_keyword_error_rate_with_pattern의 문장 존재 여부 기반 집계 방식 유지.
 - 새 표준식과 유니코드 정규화는 모두 명시적으로 선택할 때만 적용.
+- evaluate_entities는 새 API로만 추가하고 기존 함수의 계산 및 매칭 결과는 변경하지 않음.
+- evaluate_entities도 rate_mode="normalized", unicode_normalization=None을 기본값으로 사용.
 
 ### Tests
 - 기본값 고정, 표준식, 빈 참조문장, 유니코드 정규화, 코퍼스 집계, 반복 키워드, 오탐, 오류 정렬 테스트 추가.
-- 기존 19개 테스트를 포함해 총 39개 테스트로 회귀 범위 확대.
+- 개체명 span CER, 별칭 opt-in, 조사·띄어쓰기, 내부/외부 삽입, 반복 언급, 라벨 집계, 입력 검증 테스트 추가.
+- 기존 테스트를 포함해 총 50개 테스트로 회귀 범위 확대.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Nlptutti 기본 정규화 오류율:
 - English: https://hyeonsangjeon.github.io/job-transcribe/en/
 
 ### 사용자 매뉴얼
-설치부터 CER/WER/CRR, 코퍼스 평가, 키워드·개체명 보존 평가, 오류 상세 분석까지 함수별 예제를 제공합니다.
+설치부터 CER/WER/CRR, 코퍼스 평가, Entity CER·개체명 F1, 키워드 보존 평가, 오류 상세 분석까지 함수별 예제를 제공합니다.
 - Korean manual: https://hyeonsangjeon.github.io/job-transcribe/nlptutti/
 
 ### 사용방법 
@@ -67,6 +67,7 @@ pip install nlptutti
 - 참조문장은 비어 있고 가설문장만 있는 경우에는 전체를 삽입 오류로 계산합니다.
 - CER/CRR 계산에서는 `rm_punctuation` 값과 관계없이 공백을 제거합니다. `rm_punctuation`은 문장부호 제거 여부만 제어합니다.
 - 키워드 패턴은 정규식 특수문자를 포함한 키워드도 안전하게 처리하며, 긴 단어 내부의 부분문자열 오탐을 줄이기 위해 키워드 앞뒤 경계를 검사합니다.
+- `evaluate_entities`의 별칭은 `aliases`에 직접 지정한 경우에만 정답으로 인정합니다. 발음 유사도나 퍼지 매칭은 자동으로 적용하지 않습니다.
 - `calculate_keyword_error_rate_with_pattern`은 참조문장 리스트와 STT 결과 리스트의 길이가 다르면 `ValueError`를 발생시킵니다.
 
 #### CER
@@ -155,9 +156,45 @@ print(report["cer"]["micro"])  # 0.4
 print(report["cer"]["macro"])  # 0.41666666666666663
 ~~~
 
+### 개체명 중심 평가 (evaluate_entities)
+
+전체 문장 CER와 별도로 회사명, 사람 이름, 상품명처럼 중요한 개체명 구간의 문자 오류율과 언급 보존 성능을 함께 평가합니다. 논문의 Named Entity WER(NE-WER)처럼 참조 개체명 span에 정렬된 오류만 Entity CER로 집계하되, 한국어에서는 단어 경계의 영향을 줄이기 위해 문자 단위로 계산합니다.[3] 개체명의 추가 인식과 누락은 precision, recall, F1으로 별도 집계합니다.
+
+~~~python
+import nlptutti as metrics
+
+report = metrics.evaluate_entities(
+    ["삼성전자의 갤럭시 S26 발표"],
+    ["삼성전다의 갤럭시 에스 이십육 발표와 애플"],
+    {
+        "ORG": ["삼성전자", "애플"],
+        "PRODUCT": ["갤럭시 S26"],
+    },
+    aliases={
+        "갤럭시 S26": ["갤럭시 에스 이십육"],
+    },
+)
+
+print(report["entity_cer"]["micro"])  # 0.1
+print(report["summary"]["f1"])  # 0.5
+print(report["labels"]["PRODUCT"]["f1"])  # 1.0
+print([(e["type"], e["entity"]) for e in report["errors"]])
+# [("misrecognition", "삼성전자"), ("addition", "애플")]
+~~~
+
+- **Entity CER:** 참조 개체명 span 내부의 치환·삭제·삽입을 문자 단위로 계산합니다. `micro`는 전체 편집 횟수 기반, `macro`는 개체명 언급별 평균입니다.
+- **계산식 선택:** 기존 사용자 호환성을 위해 기본값은 `rate_mode="normalized"`입니다. 논문의 NE-WER처럼 참조 개체명 문자 수를 분모로 보고하려면 `rate_mode="standard"`를 지정합니다. Entity CER는 NE-WER의 문자 단위 응용이며 논문 구현을 그대로 재현한 지표는 아닙니다.
+- **개체명 F1:** 정확한 개체명 언급과 명시적으로 허용한 별칭을 기준으로 추가·누락을 계산합니다.
+- **한국어 처리:** 개체명 내부 띄어쓰기와 기본 조사·어미 결합을 허용합니다. 조사는 Entity CER span에서 제외됩니다.
+- **별칭 정책:** `aliases`는 숫자 읽기나 영문 표기의 허용 가능한 전사형처럼 실제로 같은 개체인 표현만 등록합니다. 등록하지 않은 유사 표현은 오류입니다.
+- **오탐 해석:** 참조에 없는 개체명의 추가 인식은 Entity CER가 아니라 precision/F1과 `errors`의 `addition`으로 확인합니다.
+- **모델 범위:** 이 함수는 NER 모델을 실행하지 않습니다. 사용자가 제공한 개체명 사전을 평가합니다.
+
+NE-WER는 일반 WER를 참조 개체명 단어에 제한한 지표로 설명되며, 최근 Spoken NER 연구의 NEER도 전체 WER를 대체하기보다 도메인 핵심어 분석을 보완하는 지표로 다룹니다.[3][4] ASR 오류와 개체명 인식 오류의 관계를 분석한 연구도 있어 Entity CER와 F1을 함께 확인하는 편이 안전합니다.[5]
+
 ### 키워드·개체명 보존 평가 (evaluate_keywords)
 
-문장별 실제 언급 횟수를 기준으로 누락과 추가 인식을 함께 집계합니다. 라벨 딕셔너리를 넘기면 ORG, PRODUCT 같은 유형별 결과도 제공합니다. 이 함수는 키워드 목록을 평가하며 NER 모델을 실행하지는 않습니다.
+문장별 실제 언급 횟수를 기준으로 누락과 추가 인식을 함께 집계합니다. 라벨 딕셔너리를 넘기면 ORG, PRODUCT 같은 유형별 결과도 제공합니다. 문자 단위 Entity CER와 별칭, 오류 목록까지 필요하면 `evaluate_entities`를 사용하십시오. 두 함수 모두 키워드·개체명 목록을 평가하며 NER 모델을 실행하지는 않습니다.
 
 ~~~python
 import nlptutti as metrics
@@ -348,6 +385,11 @@ print(f"전체 키워드 에러율: {s['keyword_error_rate']:.1%}")
 - 형태소 변이, 띄어쓰기 오류, 조사·어미 결합 등 한국어 STT 결과의 자연스러운 변형을 고려하여 키워드 인식 성능을 신뢰성 있게 평가합니다.
 - 특히 고유명사, 신조어, 전문용어 등 특정 단어의 인식률 분석 시 유용합니다.
 
-### References 
-- `[1]`. Word Error Rate, https://en.wikipedia.org/wiki/Word_error_rate
-- `[2]`. Computing error rates, Text Digitisation, https://sites.google.com/site/textdigitisation/qualitymeasures/computingerrorrates
+### References
+- `[1]`. [Word Error Rate](https://en.wikipedia.org/wiki/Word_error_rate)
+- `[2]`. [Computing error rates, Text Digitisation](https://sites.google.com/site/textdigitisation/qualitymeasures/computingerrorrates)
+- `[3]`. Galibert et al., [Generating Task-Pertinent sorted Error Lists for Speech Recognition](https://aclanthology.org/L16-1297/), LREC 2016. NE-WER를 참조 개체명 span에 제한된 WER로 설명합니다.
+- `[4]`. Le-Duc et al., [Medical Spoken Named Entity Recognition](https://aclanthology.org/2025.naacl-industry.59/), NAACL 2025. WER·KER를 보완하는 Named-Entity-Error-Rate를 논의합니다.
+- `[5]`. Szymański et al., [Why Aren't We NER Yet? Artifacts of ASR Errors in Named Entity Recognition in Spontaneous Speech Transcripts](https://aclanthology.org/2023.acl-long.98/), ACL 2023. ASR 오류와 개체명 인식 오류의 관계 및 오류 유형을 분석합니다.
+- `[6]`. Gong et al., [BR-ASR: Efficient and Scalable Bias Retrieval Framework for Contextual Biasing ASR in Speech LLM](https://www.isca-archive.org/interspeech_2025/gong25_interspeech.html), Interspeech 2025. 일반 WER와 별도로 bias word 성능을 보고합니다.
+- `[7]`. K et al., [Advocating Character Error Rate for Multilingual ASR Evaluation](https://aclanthology.org/2025.findings-naacl.277/), NAACL 2025 Findings. 단어 경계와 형태가 다양한 다국어 ASR에서 CER 병행의 근거를 제시합니다.

--- a/nlptutti/__init__.py
+++ b/nlptutti/__init__.py
@@ -10,12 +10,14 @@ from nlptutti.asr_metrics import (
     get_wer,
     make_keyword_pattern,
 )
+from nlptutti.entity_metrics import evaluate_entities
 
 __all__ = [
     "COMPLEX_EOMI",
     "COMPLEX_JOSA",
     "calculate_keyword_error_rate_with_pattern",
     "evaluate_corpus",
+    "evaluate_entities",
     "evaluate_keywords",
     "explain_errors",
     "get_cer",

--- a/nlptutti/entity_metrics.py
+++ b/nlptutti/entity_metrics.py
@@ -1,0 +1,865 @@
+import re
+import string
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Pattern,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from nlptutti.asr_metrics import (
+    COMPLEX_EOMI,
+    COMPLEX_JOSA,
+    _KOREAN_TOKEN_CHAR,
+    _build_keyword_statistics,
+    _calculate_error_rate,
+    _coerce_sentence_pairs,
+    _make_suffix_pattern,
+    _normalize_unicode,
+    _preprocess_cer_text,
+    _prepare_keyword_entries,
+    _resolve_rate_mode,
+    _resolve_unicode_normalization,
+)
+
+
+_MENTION_COUNT_NAMES = (
+    "reference_count",
+    "hypothesis_count",
+    "true_positives",
+    "false_positives",
+    "false_negatives",
+)
+_CHARACTER_COUNT_NAMES = (
+    "hits",
+    "substitutions",
+    "deletions",
+    "insertions",
+)
+
+
+def _empty_mention_counts() -> Dict[str, int]:
+    return {name: 0 for name in _MENTION_COUNT_NAMES}
+
+
+def _empty_character_counts() -> Dict[str, int]:
+    return {name: 0 for name in _CHARACTER_COUNT_NAMES}
+
+
+@dataclass(frozen=True)
+class _EntityDefinition:
+    name: str
+    label: Optional[str]
+    canonical_text: str
+    aliases: Tuple[str, ...]
+    pattern: Pattern
+
+
+@dataclass(frozen=True)
+class _EntityOccurrence:
+    name: str
+    label: Optional[str]
+    surface: str
+    start: int
+    end: int
+
+
+@dataclass
+class _OccurrenceScore:
+    counts: Dict[str, int] = field(default_factory=_empty_character_counts)
+    alignment: List[Dict[str, object]] = field(default_factory=list)
+
+
+def _compact_surface(surface: str) -> str:
+    return re.sub(r"\s+", "", surface)
+
+
+def _coerce_affixes(values: Sequence[str], name: str) -> List[str]:
+    if isinstance(values, (str, bytes)):
+        raise TypeError(f"{name} must be a sequence of strings")
+    resolved = list(values)
+    if not all(isinstance(value, str) for value in resolved):
+        raise TypeError(f"every value in {name} must be a string")
+    return resolved
+
+
+def _coerce_alias_values(
+    aliases: Union[str, Sequence[str]], entity_name: str
+) -> List[str]:
+    if isinstance(aliases, str):
+        values = [aliases]
+    elif isinstance(aliases, bytes) or isinstance(aliases, Mapping):
+        raise TypeError(f"aliases for {entity_name!r} must be strings")
+    else:
+        try:
+            values = list(aliases)
+        except TypeError as error:
+            raise TypeError(f"aliases for {entity_name!r} must be strings") from error
+    if not all(isinstance(value, str) for value in values):
+        raise TypeError(f"aliases for {entity_name!r} must be strings")
+    return values
+
+
+def _prepare_aliases(
+    entries: Sequence[Tuple[str, Optional[str]]],
+    aliases: Optional[Mapping[str, Union[str, Sequence[str]]]],
+    unicode_normalization: Optional[str],
+) -> Dict[str, List[str]]:
+    aliases_by_entity = {name: [] for name, _ in entries}
+    if aliases is None:
+        return aliases_by_entity
+    if not isinstance(aliases, Mapping):
+        raise TypeError("aliases must be a mapping from entity names to strings")
+
+    for raw_name, raw_aliases in aliases.items():
+        if not isinstance(raw_name, str):
+            raise TypeError("every aliases key must be an entity name string")
+        name = raw_name.strip()
+        if name not in aliases_by_entity:
+            raise ValueError(f"aliases contains an unknown entity: {raw_name!r}")
+        for raw_alias in _coerce_alias_values(raw_aliases, name):
+            alias = _normalize_unicode(raw_alias.strip(), unicode_normalization)
+            if not alias:
+                raise ValueError(f"aliases for {name!r} must not contain empty values")
+            aliases_by_entity[name].append(alias)
+    return aliases_by_entity
+
+
+def _validate_surface_ownership(
+    canonical_texts: Mapping[str, str],
+    aliases_by_entity: Mapping[str, Sequence[str]],
+) -> None:
+    owners = {}
+    for name, canonical_text in canonical_texts.items():
+        key = _compact_surface(canonical_text)
+        if key in owners:
+            raise ValueError(
+                "entities must remain unique after Unicode and whitespace normalization"
+            )
+        owners[key] = name
+
+    for name, aliases in aliases_by_entity.items():
+        canonical_key = _compact_surface(canonical_texts[name])
+        seen = set()
+        for alias in aliases:
+            alias_key = _compact_surface(alias)
+            if alias_key == canonical_key:
+                raise ValueError(
+                    f"alias {alias!r} for {name!r} duplicates its canonical form"
+                )
+            owner = owners.get(alias_key)
+            if owner is not None and owner != name:
+                raise ValueError(
+                    f"alias {alias!r} is ambiguous between {name!r} and {owner!r}"
+                )
+            if alias_key in seen:
+                raise ValueError(f"aliases for {name!r} must be unique")
+            seen.add(alias_key)
+            owners[alias_key] = name
+
+
+def _make_entity_pattern(
+    surfaces: Sequence[str],
+    josa_list: Sequence[str],
+    eomi_list: Sequence[str],
+) -> Pattern:
+    variants = [
+        r"\s*".join(re.escape(char) for char in _compact_surface(surface))
+        for surface in sorted(
+            surfaces,
+            key=lambda value: (-len(_compact_surface(value)), value),
+        )
+    ]
+    entity_pattern = "|".join(variants)
+    suffix_pattern = _make_suffix_pattern(josa_list, eomi_list)
+    suffix = rf"(?:\s*(?:{suffix_pattern}))?" if suffix_pattern else ""
+    return re.compile(
+        rf"(?<![{_KOREAN_TOKEN_CHAR}])"
+        rf"(?P<entity>{entity_pattern})"
+        rf"{suffix}"
+        rf"(?![{_KOREAN_TOKEN_CHAR}])"
+    )
+
+
+def _prepare_definitions(
+    entities: Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]],
+    aliases: Optional[Mapping[str, Union[str, Sequence[str]]]],
+    josa_list: Sequence[str],
+    eomi_list: Sequence[str],
+    unicode_normalization: Optional[str],
+) -> Tuple[List[_EntityDefinition], bool]:
+    entries, is_labeled = _prepare_keyword_entries(entities)
+    canonical_texts = {
+        name: _normalize_unicode(name, unicode_normalization) for name, _ in entries
+    }
+    aliases_by_entity = _prepare_aliases(entries, aliases, unicode_normalization)
+    _validate_surface_ownership(canonical_texts, aliases_by_entity)
+
+    definitions = [
+        _EntityDefinition(
+            name=name,
+            label=label,
+            canonical_text=canonical_texts[name],
+            aliases=tuple(aliases_by_entity[name]),
+            pattern=_make_entity_pattern(
+                (canonical_texts[name],) + tuple(aliases_by_entity[name]),
+                josa_list,
+                eomi_list,
+            ),
+        )
+        for name, label in entries
+    ]
+    return definitions, is_labeled
+
+
+def _select_entity_candidates(
+    text: str, definitions: Sequence[_EntityDefinition]
+) -> List[Tuple[int, int, int, str]]:
+    candidates = []
+    for definition_index, definition in enumerate(definitions):
+        for match in definition.pattern.finditer(text):
+            start, end = match.span("entity")
+            candidates.append((start, end, definition_index, match.group("entity")))
+
+    selected = []
+    previous_end = -1
+    for candidate in sorted(
+        candidates,
+        key=lambda item: (item[0], -(item[1] - item[0]), item[2]),
+    ):
+        if candidate[0] >= previous_end:
+            selected.append(candidate)
+            previous_end = candidate[1]
+    return selected
+
+
+def _canonicalize_mentions(
+    text: str,
+    definitions: Sequence[_EntityDefinition],
+    unicode_normalization: Optional[str],
+) -> Tuple[str, List[_EntityOccurrence]]:
+    normalized_text = _normalize_unicode(text, unicode_normalization)
+    candidates = _select_entity_candidates(normalized_text, definitions)
+    pieces = []
+    occurrences = []
+    source_cursor = 0
+    output_length = 0
+
+    for start, end, definition_index, surface in candidates:
+        definition = definitions[definition_index]
+        prefix = normalized_text[source_cursor:start]
+        pieces.extend((prefix, definition.canonical_text))
+        output_length += len(prefix)
+        occurrence_start = output_length
+        output_length += len(definition.canonical_text)
+        occurrences.append(
+            _EntityOccurrence(
+                name=definition.name,
+                label=definition.label,
+                surface=surface,
+                start=occurrence_start,
+                end=output_length,
+            )
+        )
+        source_cursor = end
+
+    pieces.append(normalized_text[source_cursor:])
+    return "".join(pieces), occurrences
+
+
+def _preprocess_with_offsets(text: str, rm_punctuation: bool) -> Tuple[str, List[int]]:
+    characters = []
+    offsets = []
+    for offset, character in enumerate(text):
+        if character in string.whitespace:
+            continue
+        if rm_punctuation and unicodedata.category(character).startswith("P"):
+            continue
+        characters.append(character)
+        offsets.append(offset)
+    return "".join(characters), offsets
+
+
+def _align_with_indices(
+    reference: Sequence[str], hypothesis: Sequence[str]
+) -> List[Dict[str, object]]:
+    reference_length = len(reference)
+    hypothesis_length = len(hypothesis)
+    costs = [[0] * (hypothesis_length + 1) for _ in range(reference_length + 1)]
+    backtrace = [[None] * (hypothesis_length + 1) for _ in range(reference_length + 1)]
+
+    for ref_index in range(1, reference_length + 1):
+        costs[ref_index][0] = ref_index
+        backtrace[ref_index][0] = "delete"
+    for hyp_index in range(1, hypothesis_length + 1):
+        costs[0][hyp_index] = hyp_index
+        backtrace[0][hyp_index] = "insert"
+
+    for ref_index in range(1, reference_length + 1):
+        for hyp_index in range(1, hypothesis_length + 1):
+            is_equal = reference[ref_index - 1] == hypothesis[hyp_index - 1]
+            candidates = [
+                (
+                    costs[ref_index - 1][hyp_index - 1] + int(not is_equal),
+                    "equal" if is_equal else "substitute",
+                ),
+                (costs[ref_index][hyp_index - 1] + 1, "insert"),
+                (costs[ref_index - 1][hyp_index] + 1, "delete"),
+            ]
+            costs[ref_index][hyp_index], backtrace[ref_index][hyp_index] = min(
+                candidates, key=lambda candidate: candidate[0]
+            )
+
+    alignment = []
+    ref_index = reference_length
+    hyp_index = hypothesis_length
+    while ref_index > 0 or hyp_index > 0:
+        operation = backtrace[ref_index][hyp_index]
+        if operation in ("equal", "substitute"):
+            alignment.append(
+                {
+                    "type": operation,
+                    "reference": reference[ref_index - 1],
+                    "hypothesis": hypothesis[hyp_index - 1],
+                    "reference_index": ref_index - 1,
+                    "reference_position": ref_index - 1,
+                }
+            )
+            ref_index -= 1
+            hyp_index -= 1
+        elif operation == "insert":
+            alignment.append(
+                {
+                    "type": operation,
+                    "reference": "",
+                    "hypothesis": hypothesis[hyp_index - 1],
+                    "reference_index": None,
+                    "reference_position": ref_index,
+                }
+            )
+            hyp_index -= 1
+        else:
+            alignment.append(
+                {
+                    "type": "delete",
+                    "reference": reference[ref_index - 1],
+                    "hypothesis": "",
+                    "reference_index": ref_index - 1,
+                    "reference_position": ref_index - 1,
+                }
+            )
+            ref_index -= 1
+
+    alignment.reverse()
+    return alignment
+
+
+def _map_occurrence_tokens(
+    occurrences: Sequence[_EntityOccurrence], offsets: Sequence[int]
+) -> Tuple[Dict[int, int], List[Tuple[int, int, int]]]:
+    token_to_occurrence = {}
+    intervals = []
+    for occurrence_index, occurrence in enumerate(occurrences):
+        token_indices = [
+            token_index
+            for token_index, offset in enumerate(offsets)
+            if occurrence.start <= offset < occurrence.end
+        ]
+        if token_indices:
+            for token_index in token_indices:
+                token_to_occurrence[token_index] = occurrence_index
+            intervals.append(
+                (min(token_indices), max(token_indices) + 1, occurrence_index)
+            )
+    return token_to_occurrence, intervals
+
+
+def _find_insertion_occurrence(
+    reference_position: int, intervals: Sequence[Tuple[int, int, int]]
+) -> Optional[int]:
+    for start, end, occurrence_index in intervals:
+        # Boundary insertions stay outside the entity span, as in NE-WER alignment.
+        if start < reference_position < end:
+            return occurrence_index
+    return None
+
+
+def _group_occurrences(
+    definitions: Sequence[_EntityDefinition],
+    occurrences: Sequence[_EntityOccurrence],
+) -> Dict[str, List[_EntityOccurrence]]:
+    grouped = {definition.name: [] for definition in definitions}
+    for occurrence in occurrences:
+        grouped[occurrence.name].append(occurrence)
+    return grouped
+
+
+def _measure_mentions(
+    definitions: Sequence[_EntityDefinition],
+    reference_groups: Mapping[str, Sequence[_EntityOccurrence]],
+    hypothesis_groups: Mapping[str, Sequence[_EntityOccurrence]],
+) -> Dict[str, Dict[str, int]]:
+    result = {}
+    for definition in definitions:
+        name = definition.name
+        reference_count = len(reference_groups[name])
+        hypothesis_count = len(hypothesis_groups[name])
+        true_positives = min(reference_count, hypothesis_count)
+        result[name] = {
+            "reference_count": reference_count,
+            "hypothesis_count": hypothesis_count,
+            "true_positives": true_positives,
+            "false_positives": max(hypothesis_count - reference_count, 0),
+            "false_negatives": max(reference_count - hypothesis_count, 0),
+        }
+    return result
+
+
+def _assign_alignment_to_occurrences(
+    processed_reference: str,
+    processed_hypothesis: str,
+    reference_occurrences: Sequence[_EntityOccurrence],
+    reference_offsets: Sequence[int],
+) -> List[_OccurrenceScore]:
+    token_to_occurrence, intervals = _map_occurrence_tokens(
+        reference_occurrences, reference_offsets
+    )
+    scores = [_OccurrenceScore() for _ in reference_occurrences]
+    if not scores:
+        return scores
+
+    for item in _align_with_indices(
+        list(processed_reference), list(processed_hypothesis)
+    ):
+        reference_index = item["reference_index"]
+        if reference_index is not None:
+            occurrence_index = token_to_occurrence.get(reference_index)
+        elif item["type"] == "insert":
+            occurrence_index = _find_insertion_occurrence(
+                item["reference_position"], intervals
+            )
+        else:
+            occurrence_index = None
+        if occurrence_index is None:
+            continue
+
+        score = scores[occurrence_index]
+        count_name = {
+            "equal": "hits",
+            "substitute": "substitutions",
+            "delete": "deletions",
+            "insert": "insertions",
+        }[item["type"]]
+        score.counts[count_name] += 1
+        score.alignment.append(item)
+    return scores
+
+
+def _make_reference_error(
+    sentence_index: int,
+    occurrence: _EntityOccurrence,
+    score: _OccurrenceScore,
+) -> Dict[str, object]:
+    reference = "".join(item["reference"] for item in score.alignment)
+    hypothesis = "".join(item["hypothesis"] for item in score.alignment)
+    result = {
+        "sentence_index": sentence_index,
+        "type": "omission" if not hypothesis else "misrecognition",
+        "entity": occurrence.name,
+        "reference": reference,
+        "hypothesis": hypothesis,
+        "substitutions": score.counts["substitutions"],
+        "deletions": score.counts["deletions"],
+        "insertions": score.counts["insertions"],
+    }
+    if occurrence.label is not None:
+        result["label"] = occurrence.label
+    return result
+
+
+def _score_reference_occurrences(
+    sentence_index: int,
+    definitions: Sequence[_EntityDefinition],
+    canonical_reference: str,
+    canonical_hypothesis: str,
+    reference_occurrences: Sequence[_EntityOccurrence],
+    rm_punctuation: bool,
+    rate_mode: str,
+) -> Tuple[
+    Dict[str, Dict[str, int]],
+    List[float],
+    List[Tuple[int, int, Dict[str, object]]],
+    Counter,
+]:
+    processed_reference, reference_offsets = _preprocess_with_offsets(
+        canonical_reference, rm_punctuation
+    )
+    processed_hypothesis, _ = _preprocess_with_offsets(
+        canonical_hypothesis, rm_punctuation
+    )
+    scores = _assign_alignment_to_occurrences(
+        processed_reference,
+        processed_hypothesis,
+        reference_occurrences,
+        reference_offsets,
+    )
+    character_counts = {
+        definition.name: _empty_character_counts() for definition in definitions
+    }
+    occurrence_rates = []
+    errors = []
+    reported_errors = Counter()
+
+    for occurrence, score in zip(reference_occurrences, scores):
+        _merge_counts(character_counts[occurrence.name], score.counts)
+        occurrence_rates.append(_character_rate(score.counts, rate_mode))
+        if _incorrect_characters(score.counts) == 0:
+            continue
+        error = _make_reference_error(sentence_index, occurrence, score)
+        errors.append((sentence_index, occurrence.start, error))
+        reported_errors[occurrence.name] += 1
+    return character_counts, occurrence_rates, errors, reported_errors
+
+
+def _make_unmatched_errors(
+    sentence_index: int,
+    definitions: Sequence[_EntityDefinition],
+    reference_groups: Mapping[str, Sequence[_EntityOccurrence]],
+    hypothesis_groups: Mapping[str, Sequence[_EntityOccurrence]],
+    reported_errors: Mapping[str, int],
+    scorable_texts: Mapping[str, str],
+) -> List[Tuple[int, int, Dict[str, object]]]:
+    errors = []
+    for definition in definitions:
+        name = definition.name
+        references = reference_groups[name]
+        hypotheses = hypothesis_groups[name]
+        missing = max(len(references) - len(hypotheses) - reported_errors[name], 0)
+        for occurrence in references[-missing:] if missing else []:
+            error = {
+                "sentence_index": sentence_index,
+                "type": "omission",
+                "entity": name,
+                "reference": scorable_texts[name],
+                "hypothesis": "",
+                "substitutions": 0,
+                "deletions": len(scorable_texts[name]),
+                "insertions": 0,
+            }
+            if definition.label is not None:
+                error["label"] = definition.label
+            errors.append((sentence_index, occurrence.start, error))
+
+        additions = max(len(hypotheses) - len(references), 0)
+        for occurrence in hypotheses[-additions:] if additions else []:
+            error = {
+                "sentence_index": sentence_index,
+                "type": "addition",
+                "entity": name,
+                "reference": "",
+                "hypothesis": occurrence.surface,
+                "substitutions": 0,
+                "deletions": 0,
+                "insertions": len(scorable_texts[name]),
+            }
+            if definition.label is not None:
+                error["label"] = definition.label
+            errors.append((sentence_index, occurrence.start, error))
+    return errors
+
+
+def _evaluate_sentence(
+    sentence_index: int,
+    reference: str,
+    hypothesis: str,
+    definitions: Sequence[_EntityDefinition],
+    scorable_texts: Mapping[str, str],
+    rm_punctuation: bool,
+    rate_mode: str,
+    unicode_normalization: Optional[str],
+) -> Tuple[
+    Dict[str, Dict[str, int]],
+    Dict[str, Dict[str, int]],
+    List[float],
+    List[Tuple[int, int, Dict[str, object]]],
+]:
+    canonical_reference, reference_occurrences = _canonicalize_mentions(
+        reference, definitions, unicode_normalization
+    )
+    canonical_hypothesis, hypothesis_occurrences = _canonicalize_mentions(
+        hypothesis, definitions, unicode_normalization
+    )
+    reference_groups = _group_occurrences(definitions, reference_occurrences)
+    hypothesis_groups = _group_occurrences(definitions, hypothesis_occurrences)
+    mentions = _measure_mentions(definitions, reference_groups, hypothesis_groups)
+    characters, rates, errors, reported = _score_reference_occurrences(
+        sentence_index,
+        definitions,
+        canonical_reference,
+        canonical_hypothesis,
+        reference_occurrences,
+        rm_punctuation,
+        rate_mode,
+    )
+    errors.extend(
+        _make_unmatched_errors(
+            sentence_index,
+            definitions,
+            reference_groups,
+            hypothesis_groups,
+            reported,
+            scorable_texts,
+        )
+    )
+    return mentions, characters, rates, errors
+
+
+def _merge_counts(target: Dict[str, int], source: Mapping[str, int]) -> None:
+    for name in target:
+        target[name] += source[name]
+
+
+def _incorrect_characters(counts: Mapping[str, int]) -> int:
+    return counts["substitutions"] + counts["deletions"] + counts["insertions"]
+
+
+def _character_rate(counts: Mapping[str, int], rate_mode: str) -> float:
+    return _calculate_error_rate(
+        counts["substitutions"],
+        counts["deletions"],
+        counts["insertions"],
+        counts["hits"],
+        rate_mode,
+    )
+
+
+def _character_statistics(
+    counts: Mapping[str, int], rate_mode: str
+) -> Dict[str, Union[float, int]]:
+    return {
+        "cer": _character_rate(counts, rate_mode),
+        "hits": counts["hits"],
+        "substitutions": counts["substitutions"],
+        "deletions": counts["deletions"],
+        "insertions": counts["insertions"],
+        "reference_characters": (
+            counts["hits"] + counts["substitutions"] + counts["deletions"]
+        ),
+    }
+
+
+def _aggregate_nested_counts(
+    target: Mapping[str, Dict[str, int]],
+    source: Mapping[str, Mapping[str, int]],
+) -> None:
+    for name, counts in source.items():
+        _merge_counts(target[name], counts)
+
+
+def _build_entity_results(
+    definitions: Sequence[_EntityDefinition],
+    mention_counts: Mapping[str, Mapping[str, int]],
+    character_counts: Mapping[str, Mapping[str, int]],
+    rate_mode: str,
+    is_labeled: bool,
+) -> Dict[str, Dict[str, object]]:
+    results = {}
+    for definition in definitions:
+        statistics = _build_keyword_statistics(**mention_counts[definition.name])
+        statistics.update(
+            _character_statistics(character_counts[definition.name], rate_mode)
+        )
+        statistics["aliases"] = list(definition.aliases)
+        if is_labeled:
+            statistics["label"] = definition.label
+        results[definition.name] = statistics
+    return results
+
+
+def _sum_nested_counts(
+    values: Iterable[Mapping[str, int]], names: Sequence[str]
+) -> Dict[str, int]:
+    total = {name: 0 for name in names}
+    for counts in values:
+        _merge_counts(total, counts)
+    return total
+
+
+def _build_label_results(
+    definitions: Sequence[_EntityDefinition],
+    mention_counts: Mapping[str, Mapping[str, int]],
+    character_counts: Mapping[str, Mapping[str, int]],
+    rate_mode: str,
+) -> Dict[str, Dict[str, object]]:
+    label_mentions = {}
+    label_characters = {}
+    for definition in definitions:
+        label = definition.label
+        label_mentions.setdefault(label, _empty_mention_counts())
+        label_characters.setdefault(label, _empty_character_counts())
+        _merge_counts(label_mentions[label], mention_counts[definition.name])
+        _merge_counts(label_characters[label], character_counts[definition.name])
+
+    results = {}
+    for label, counts in label_mentions.items():
+        statistics = _build_keyword_statistics(**counts)
+        statistics.update(_character_statistics(label_characters[label], rate_mode))
+        results[label] = statistics
+    return results
+
+
+def _build_final_result(
+    definitions: Sequence[_EntityDefinition],
+    is_labeled: bool,
+    mention_counts: Mapping[str, Mapping[str, int]],
+    character_counts: Mapping[str, Mapping[str, int]],
+    occurrence_rates: Sequence[float],
+    error_records: Sequence[Tuple[int, int, Dict[str, object]]],
+    rate_mode: str,
+    rm_punctuation: bool,
+    unicode_normalization: Optional[str],
+) -> Dict[str, object]:
+    entity_results = _build_entity_results(
+        definitions, mention_counts, character_counts, rate_mode, is_labeled
+    )
+    total_mentions = _sum_nested_counts(mention_counts.values(), _MENTION_COUNT_NAMES)
+    total_characters = _sum_nested_counts(
+        character_counts.values(), _CHARACTER_COUNT_NAMES
+    )
+    character_statistics = _character_statistics(total_characters, rate_mode)
+    entity_cer = {
+        "micro": character_statistics["cer"],
+        "macro": (
+            sum(occurrence_rates) / len(occurrence_rates) if occurrence_rates else 0.0
+        ),
+        **{name: character_statistics[name] for name in _CHARACTER_COUNT_NAMES},
+        "reference_characters": character_statistics["reference_characters"],
+    }
+    result = {
+        "rate_mode": rate_mode,
+        "rm_punctuation": rm_punctuation,
+        "unicode_normalization": unicode_normalization,
+        "aliases_enabled": any(definition.aliases for definition in definitions),
+        "entity_cer": entity_cer,
+        "entities": entity_results,
+        "summary": _build_keyword_statistics(**total_mentions),
+        "errors": [
+            record
+            for _, _, record in sorted(
+                error_records,
+                key=lambda item: (item[0], item[1], item[2]["type"]),
+            )
+        ],
+    }
+    if is_labeled:
+        result["labels"] = _build_label_results(
+            definitions, mention_counts, character_counts, rate_mode
+        )
+    return result
+
+
+def evaluate_entities(
+    reference_sentences: Iterable[str],
+    hypothesis_sentences: Iterable[str],
+    entities: Union[str, Sequence[str], Mapping[str, Union[str, Sequence[str]]]],
+    josa_list: Optional[Sequence[str]] = None,
+    eomi_list: Optional[Sequence[str]] = None,
+    rm_punctuation: bool = True,
+    *,
+    aliases: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
+    rate_mode: str = "normalized",
+    unicode_normalization: Optional[str] = None,
+) -> Dict[str, object]:
+    """Evaluate supplied entity names with mention F1 and entity-span CER.
+
+    This function locates supplied entity names; it does not run an NER model.
+    Entity CER adapts named-entity WER to characters by counting edits aligned
+    to reference entity spans. False-positive mentions outside those spans are
+    represented by mention precision/F1 and the ``errors`` list.
+
+    ``rate_mode="normalized"`` preserves the package default. Use
+    ``rate_mode="standard"`` for the paper-style denominator: the number of
+    reference entity characters.
+
+    Configured aliases are exact accepted forms, not fuzzy matches. They are
+    canonicalized before character alignment so an accepted alias is scored as
+    a correct entity mention.
+    """
+    references, hypotheses = _coerce_sentence_pairs(
+        reference_sentences, hypothesis_sentences
+    )
+    rate_mode = _resolve_rate_mode(rate_mode)
+    unicode_normalization = _resolve_unicode_normalization(unicode_normalization)
+    resolved_josa = _coerce_affixes(
+        COMPLEX_JOSA if josa_list is None else josa_list, "josa_list"
+    )
+    resolved_eomi = _coerce_affixes(
+        COMPLEX_EOMI if eomi_list is None else eomi_list, "eomi_list"
+    )
+    definitions, is_labeled = _prepare_definitions(
+        entities,
+        aliases,
+        resolved_josa,
+        resolved_eomi,
+        unicode_normalization,
+    )
+    scorable_texts = {
+        definition.name: _preprocess_cer_text(
+            definition.canonical_text, rm_punctuation, unicode_normalization=None
+        )
+        for definition in definitions
+    }
+    for name, text in scorable_texts.items():
+        if not text:
+            raise ValueError(
+                f"entity {name!r} has no scorable characters after preprocessing"
+            )
+
+    mention_counts = {
+        definition.name: _empty_mention_counts() for definition in definitions
+    }
+    character_counts = {
+        definition.name: _empty_character_counts() for definition in definitions
+    }
+    occurrence_rates = []
+    error_records = []
+    for sentence_index, (reference, hypothesis) in enumerate(
+        zip(references, hypotheses)
+    ):
+        mentions, characters, rates, errors = _evaluate_sentence(
+            sentence_index,
+            reference,
+            hypothesis,
+            definitions,
+            scorable_texts,
+            rm_punctuation,
+            rate_mode,
+            unicode_normalization,
+        )
+        _aggregate_nested_counts(mention_counts, mentions)
+        _aggregate_nested_counts(character_counts, characters)
+        occurrence_rates.extend(rates)
+        error_records.extend(errors)
+
+    return _build_final_result(
+        definitions,
+        is_labeled,
+        mention_counts,
+        character_counts,
+        occurrence_rates,
+        error_records,
+        rate_mode,
+        rm_punctuation,
+        unicode_normalization,
+    )
+
+
+__all__ = ["evaluate_entities"]

--- a/test/test_evaluate_entities.py
+++ b/test/test_evaluate_entities.py
@@ -1,0 +1,214 @@
+import unicodedata
+import unittest
+
+import nlptutti as nt
+
+
+class TestEntityEvaluation(unittest.TestCase):
+    def test_public_api_reports_entity_cer_f1_labels_and_errors(self):
+        report = nt.evaluate_entities(
+            ["삼성전자의 갤럭시 S26 발표"],
+            ["삼성전다의 갤럭시 S26 발표와 애플"],
+            {
+                "ORG": ["삼성전자", "애플"],
+                "PRODUCT": ["갤럭시 S26"],
+            },
+        )
+
+        self.assertEqual(report["rate_mode"], "normalized")
+        self.assertAlmostEqual(report["entity_cer"]["micro"], 1 / 10)
+        self.assertAlmostEqual(report["entity_cer"]["macro"], 1 / 8)
+        self.assertEqual(report["entity_cer"]["substitutions"], 1)
+        self.assertEqual(report["summary"]["true_positives"], 1)
+        self.assertEqual(report["summary"]["false_positives"], 1)
+        self.assertEqual(report["summary"]["false_negatives"], 1)
+        self.assertEqual(report["summary"]["f1"], 0.5)
+        self.assertEqual(report["labels"]["PRODUCT"]["f1"], 1.0)
+        self.assertEqual(
+            [(item["type"], item["entity"]) for item in report["errors"]],
+            [("misrecognition", "삼성전자"), ("addition", "애플")],
+        )
+        self.assertEqual(report["errors"][0]["hypothesis"], "삼성전다")
+
+    def test_aliases_are_opt_in_and_score_as_exact_when_configured(self):
+        reference = ["갤럭시 S26을 공개했다"]
+        hypothesis = ["갤럭시 에스 이십육을 공개했다"]
+        entities = {"PRODUCT": ["갤럭시 S26"]}
+
+        strict_report = nt.evaluate_entities(reference, hypothesis, entities)
+        alias_report = nt.evaluate_entities(
+            reference,
+            hypothesis,
+            entities,
+            aliases={"갤럭시 S26": ["갤럭시 에스 이십육"]},
+        )
+
+        self.assertEqual(strict_report["summary"]["false_negatives"], 1)
+        self.assertGreater(strict_report["entity_cer"]["micro"], 0.0)
+        self.assertFalse(strict_report["aliases_enabled"])
+        self.assertEqual(alias_report["summary"]["f1"], 1.0)
+        self.assertEqual(alias_report["entity_cer"]["micro"], 0.0)
+        self.assertEqual(alias_report["errors"], [])
+        self.assertTrue(alias_report["aliases_enabled"])
+
+    def test_spacing_and_korean_suffixes_do_not_change_entity_score(self):
+        report = nt.evaluate_entities(
+            ["삼성전자의 실적"],
+            ["삼성 전자는 실적"],
+            ["삼성전자"],
+        )
+
+        self.assertEqual(report["summary"]["f1"], 1.0)
+        self.assertEqual(report["entity_cer"]["micro"], 0.0)
+        self.assertEqual(report["entities"]["삼성전자"]["hits"], 4)
+
+    def test_entity_internal_insertion_respects_rate_mode(self):
+        normalized = nt.evaluate_entities(
+            ["삼성전자"],
+            ["삼성대전자"],
+            ["삼성전자"],
+        )
+        standard = nt.evaluate_entities(
+            ["삼성전자"],
+            ["삼성대전자"],
+            ["삼성전자"],
+            rate_mode="standard",
+        )
+
+        self.assertAlmostEqual(normalized["entity_cer"]["micro"], 1 / 5)
+        self.assertAlmostEqual(standard["entity_cer"]["micro"], 1 / 4)
+        self.assertEqual(normalized["entity_cer"]["insertions"], 1)
+        self.assertEqual(normalized["errors"][0]["type"], "misrecognition")
+        self.assertEqual(normalized["errors"][0]["hypothesis"], "삼성대전자")
+
+    def test_insertion_outside_entity_span_does_not_inflate_entity_cer(self):
+        report = nt.evaluate_entities(
+            ["삼성전자 실적 발표"],
+            ["삼성전자 새 실적 발표"],
+            ["삼성전자"],
+        )
+
+        self.assertEqual(report["summary"]["f1"], 1.0)
+        self.assertEqual(report["entity_cer"]["micro"], 0.0)
+        self.assertEqual(report["entity_cer"]["insertions"], 0)
+        self.assertEqual(report["errors"], [])
+
+    def test_repeated_mentions_count_an_omission_and_character_deletions(self):
+        report = nt.evaluate_entities(
+            ["삼성전자와 삼성전자"],
+            ["삼성전자"],
+            ["삼성전자"],
+        )
+
+        self.assertEqual(report["summary"]["true_positives"], 1)
+        self.assertEqual(report["summary"]["false_negatives"], 1)
+        self.assertEqual(report["summary"]["recall"], 0.5)
+        self.assertEqual(report["entity_cer"]["deletions"], 4)
+        self.assertEqual(report["errors"][0]["type"], "omission")
+
+    def test_false_positive_mentions_are_reported_separately_from_entity_cer(self):
+        report = nt.evaluate_entities(
+            ["오늘 발표했다"],
+            ["애플이 오늘 발표했다"],
+            ["애플"],
+        )
+
+        self.assertEqual(report["summary"]["false_positives"], 1)
+        self.assertEqual(report["summary"]["precision"], 0.0)
+        self.assertEqual(report["entity_cer"]["reference_characters"], 0)
+        self.assertEqual(report["entity_cer"]["micro"], 0.0)
+        self.assertEqual(report["errors"][0]["type"], "addition")
+
+    def test_unicode_normalization_remains_opt_in(self):
+        reference = "가"
+        hypothesis = unicodedata.normalize("NFD", reference)
+
+        strict_report = nt.evaluate_entities(
+            [reference],
+            [hypothesis],
+            [reference],
+        )
+        normalized_report = nt.evaluate_entities(
+            [reference],
+            [hypothesis],
+            [reference],
+            unicode_normalization="NFC",
+        )
+
+        self.assertEqual(strict_report["summary"]["false_negatives"], 1)
+        self.assertGreater(strict_report["entity_cer"]["micro"], 0.0)
+        self.assertEqual(normalized_report["summary"]["f1"], 1.0)
+        self.assertEqual(normalized_report["entity_cer"]["micro"], 0.0)
+
+    def test_generators_are_supported(self):
+        references = (value for value in ["삼성전자", "애플"])
+        hypotheses = (value for value in ["삼성전자", "애플"])
+
+        report = nt.evaluate_entities(
+            references,
+            hypotheses,
+            {"ORG": ["삼성전자", "애플"]},
+        )
+
+        self.assertEqual(report["summary"]["true_positives"], 2)
+        self.assertEqual(report["summary"]["f1"], 1.0)
+
+    def test_aliases_reject_unknown_ambiguous_and_duplicate_surfaces(self):
+        with self.assertRaises(ValueError):
+            nt.evaluate_entities(
+                ["삼성전자"],
+                ["삼성전자"],
+                ["삼성전자"],
+                aliases={"애플": ["애플사"]},
+            )
+
+        with self.assertRaises(ValueError):
+            nt.evaluate_entities(
+                ["삼성전자"],
+                ["삼성전자"],
+                ["삼성전자", "갤럭시"],
+                aliases={"삼성전자": ["갤럭시"]},
+            )
+
+        with self.assertRaises(ValueError):
+            nt.evaluate_entities(
+                ["삼성전자"],
+                ["삼성전자"],
+                ["삼성전자"],
+                aliases={"삼성전자": ["삼성 전자"]},
+            )
+
+    def test_invalid_alias_affix_and_entity_inputs_are_rejected(self):
+        with self.assertRaises(TypeError):
+            nt.evaluate_entities(
+                ["삼성전자"],
+                ["삼성전자"],
+                ["삼성전자"],
+                aliases={"삼성전자": [1]},
+            )
+
+        with self.assertRaises(TypeError):
+            nt.evaluate_entities(
+                ["삼성전자"],
+                ["삼성전자"],
+                ["삼성전자"],
+                josa_list="의",
+            )
+
+        with self.assertRaises(ValueError):
+            nt.evaluate_entities(
+                ["..."],
+                ["..."],
+                ["..."],
+            )
+
+        with self.assertRaises(ValueError):
+            nt.evaluate_entities(
+                ["삼성전자"],
+                [],
+                ["삼성전자"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `evaluate_entities()` with entity-span CER micro/macro and mention precision, recall, and F1
- support labeled entity dictionaries, exact opt-in aliases, Korean spacing and suffix handling, and structured error records
- preserve `rate_mode="normalized"` and `unicode_normalization=None` defaults
- document the feature, compatibility policy, changelog, and primary research references

## Why
Overall CER/WER can hide errors on names, products, and domain terms. This adds a dictionary-driven entity evaluation that adapts NE-WER to Korean character units while keeping false-positive mentions visible through F1 and error records.

## Validation
- 50 tests passed on Python 3.8 through 3.14
- JiWER 3.0.0 and 4.0.0 compatibility verified
- entity module branch coverage: 93%
- 6,000 randomized preprocessing and metric invariant cases passed
- wheel and sdist built; `twine check` passed
- installed-wheel smoke tests passed on Python 3.8 and 3.14