### PR TITLE
Document and cross-check entity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Entity CER micro/macro, 개체명·라벨별 편집 횟수, 누락·추가·오인식 목록 제공.
   - 사용자가 명시한 aliases만 동일 개체의 허용 전사형으로 처리하며 퍼지 매칭은 적용하지 않음.
   - NE-WER, NEER, Spoken NER 관련 논문과 한국어 적용 기준을 README와 사용자 매뉴얼에 명시.
+  - ContextASR-Bench, NVIDIA NeMo-Skills, Teklia ie-eval, PIER의 실제 공개 구현과 Nlptutti의 차이를 README와 사용자 매뉴얼에 명시.
 - 문자·단어 단위 정렬과 치환/삭제/삽입 빈도를 보여주는 explain_errors 추가.
 - NFC, NFD, NFKC, NFKD 유니코드 정규화를 선택할 수 있는 unicode_normalization 옵션 추가.
 
@@ -45,7 +46,8 @@
 ### Tests
 - 기본값 고정, 표준식, 빈 참조문장, 유니코드 정규화, 코퍼스 집계, 반복 키워드, 오탐, 오류 정렬 테스트 추가.
 - 개체명 span CER, 별칭 opt-in, 조사·띄어쓰기, 내부/외부 삽입, 반복 언급, 라벨 집계, 입력 검증 테스트 추가.
-- 기존 테스트를 포함해 총 50개 테스트로 회귀 범위 확대.
+- PIER와 ContextASR-Bench의 고정 커밋 실행 결과를 fixture로 보존하고, 공통 동작과 문자/단어 단위 차이를 검증하는 교차 회귀 테스트 4개 추가.
+- 기존 테스트를 포함해 총 54개 테스트로 회귀 범위 확대.
 
 ---
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include test/fixtures/entity_reference_implementations.json

--- a/README.md
+++ b/README.md
@@ -192,6 +192,18 @@ print([(e["type"], e["entity"]) for e in report["errors"]])
 
 NE-WER는 일반 WER를 참조 개체명 단어에 제한한 지표로 설명되며, 최근 Spoken NER 연구의 NEER도 전체 WER를 대체하기보다 도메인 핵심어 분석을 보완하는 지표로 다룹니다.[3][4] ASR 오류와 개체명 인식 오류의 관계를 분석한 연구도 있어 Entity CER와 F1을 함께 확인하는 편이 안전합니다.[5]
 
+### 관련 공개 구현
+
+논문 설명뿐 아니라 실제 계산 코드를 확인하려면 아래 공개 구현을 함께 참고할 수 있습니다. 이름이 비슷한 지표라도 입력 형식, 매칭 정책, 계산 단위가 다르므로 점수를 그대로 서로 비교해서는 안 됩니다.
+
+| 공개 구현 | 실제 제공 기능 | Nlptutti와의 차이 |
+| --- | --- | --- |
+| [ContextASR-Bench 평가 코드](https://github.com/MrSupW/ContextASR-Bench/tree/main/evaluation) / [NVIDIA NeMo-Skills 구현](https://github.com/NVIDIA-NeMo/Skills/blob/main/nemo_skills/evaluation/evaluator/contextasr.py) | 개체명 목록을 이용해 WER, 퍼지 매칭 기반 NE-WER, 정확 일치 기반 NE-FNR 계산 | ContextASR는 개체명 단어열을 퍼지 추출한 뒤 WER를 계산합니다. Nlptutti는 퍼지 매칭을 기본으로 사용하지 않고 한국어 문자 span과 명시적 `aliases`를 평가합니다. |
+| [Teklia `ie-eval`](https://gitlab.teklia.com/ner/metrics/ie-eval) ([ECER/EWER 문서](https://doc.teklia.com/ner_ie_eval/usage/ecer_ewer/)) | BIO 정답·예측 파일로 ECER/EWER와 유형별·순서 독립 점수 계산 | Teklia는 이미 태깅된 NER 출력을 입력받습니다. Nlptutti는 원문 reference/hypothesis와 사용자가 제공한 개체명 사전을 입력받으며 NER 모델을 실행하지 않습니다. |
+| [PIER](https://github.com/enesyugan/PIER-CodeSwitching-Evaluation) | 전체 문장을 정렬한 뒤 참조의 관심 단어 위치에 해당하는 편집만 계산 | PIER는 코드 스위칭 관심 단어를 단어 단위로 평가합니다. Nlptutti Entity CER는 같은 관심 구간 평가 원칙을 한국어 문자 단위로 적용합니다. |
+
+`evaluate_entities`는 위 저장소의 코드를 포팅한 함수가 아니라, NE-WER·ECER·PIER 계열의 공통 평가 원칙을 한국어 원문과 개체명 사전 입력에 맞춰 독립적으로 구현한 API입니다. 공통 계약과 의도적인 차이는 [교차 검증 테스트](https://github.com/hyeonsangjeon/computing-Korean-STT-error-rates/blob/main/test/test_entity_reference_implementations.py)와 [고정 upstream 결과](https://github.com/hyeonsangjeon/computing-Korean-STT-error-rates/blob/main/test/fixtures/entity_reference_implementations.json)에 기록했습니다. 패키지 CI는 외부 저장소를 내려받지 않으며, 검증한 upstream 커밋과 결과를 fixture로 고정해 재현성을 유지합니다.
+
 ### 키워드·개체명 보존 평가 (evaluate_keywords)
 
 문장별 실제 언급 횟수를 기준으로 누락과 추가 인식을 함께 집계합니다. 라벨 딕셔너리를 넘기면 ORG, PRODUCT 같은 유형별 결과도 제공합니다. 문자 단위 Entity CER와 별칭, 오류 목록까지 필요하면 `evaluate_entities`를 사용하십시오. 두 함수 모두 키워드·개체명 목록을 평가하며 NER 모델을 실행하지는 않습니다.

--- a/test/fixtures/entity_reference_implementations.json
+++ b/test/fixtures/entity_reference_implementations.json
@@ -1,0 +1,109 @@
+{
+  "verified_at": "2026-07-16",
+  "implementations": {
+    "pier": {
+      "repository": "https://github.com/enesyugan/PIER-CodeSwitching-Evaluation",
+      "commit": "09535fa0311cfec98176d1a4f7bec82094bb0d4f",
+      "entrypoint": "jiwer.measures.pier",
+      "fixtures": {
+        "entity_substitution": {
+          "reference": "before A B C after",
+          "tagged_reference": "before <tag A B C> after",
+          "hypothesis": "before A X C after",
+          "entity": "A B C",
+          "upstream": {
+            "pier_percent": 33.33333333333333,
+            "hits": 2,
+            "substitutions": 1,
+            "deletions": 0,
+            "insertions": 0
+          },
+          "nlptutti": {
+            "micro": 0.3333333333333333,
+            "hits": 2,
+            "substitutions": 1,
+            "deletions": 0,
+            "insertions": 0,
+            "reference_characters": 3,
+            "f1": 0.0
+          }
+        },
+        "insertion_outside_entity": {
+          "reference": "before A B C after",
+          "tagged_reference": "before <tag A B C> after",
+          "hypothesis": "before A B C extra after",
+          "entity": "A B C",
+          "upstream": {
+            "pier_percent": 0.0,
+            "hits": 3,
+            "substitutions": 0,
+            "deletions": 0,
+            "insertions": 0,
+            "rest_insertions": 1
+          },
+          "nlptutti": {
+            "micro": 0.0,
+            "hits": 3,
+            "substitutions": 0,
+            "deletions": 0,
+            "insertions": 0,
+            "reference_characters": 3,
+            "f1": 1.0
+          }
+        }
+      }
+    },
+    "contextasr_bench": {
+      "repository": "https://github.com/MrSupW/ContextASR-Bench",
+      "commit": "897de87bd4eb430de28dca807fc725958c7ebc85",
+      "entrypoint": "evaluation/utils.py and evaluation/calculate_metrics.py",
+      "fixtures": {
+        "exact_entity_with_outside_insertion": {
+          "reference": "meet new york city today",
+          "hypothesis": "meet new york city soon today",
+          "entity": "new york city",
+          "upstream": {
+            "ne_wer": 0.0,
+            "ne_fnr": 0.0,
+            "hits": 3,
+            "substitutions": 0,
+            "deletions": 0,
+            "insertions": 0
+          },
+          "nlptutti": {
+            "micro": 0.0,
+            "hits": 11,
+            "substitutions": 0,
+            "deletions": 0,
+            "insertions": 0,
+            "reference_characters": 11,
+            "f1": 1.0
+          }
+        },
+        "fuzzy_entity_misrecognition": {
+          "reference": "meet new york city today",
+          "hypothesis": "meet new york kitty today",
+          "entity": "new york city",
+          "upstream": {
+            "ne_wer": 0.3333333333333333,
+            "ne_fnr": 1.0,
+            "hits": 2,
+            "substitutions": 1,
+            "deletions": 0,
+            "insertions": 0,
+            "reference_words": 3
+          },
+          "nlptutti": {
+            "micro": 0.18181818181818182,
+            "hits": 10,
+            "substitutions": 1,
+            "deletions": 0,
+            "insertions": 1,
+            "reference_characters": 11,
+            "f1": 0.0
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/test_entity_reference_implementations.py
+++ b/test/test_entity_reference_implementations.py
@@ -1,0 +1,91 @@
+import json
+import unittest
+from pathlib import Path
+
+import nlptutti as nt
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "entity_reference_implementations.json"
+
+
+class TestEntityReferenceImplementations(unittest.TestCase):
+    """Compare shared contracts with outputs captured from pinned upstream code."""
+
+    @classmethod
+    def setUpClass(cls):
+        with FIXTURE_PATH.open(encoding="utf-8") as fixture_file:
+            cls.fixture = json.load(fixture_file)
+
+    def _case(self, implementation, name):
+        return self.fixture["implementations"][implementation]["fixtures"][name]
+
+    def _evaluate(self, case):
+        return nt.evaluate_entities(
+            [case["reference"]],
+            [case["hypothesis"]],
+            [case["entity"]],
+            josa_list=[],
+            eomi_list=[],
+            rate_mode="standard",
+        )
+
+    def _assert_nlptutti_result(self, report, expected):
+        entity_cer = report["entity_cer"]
+        self.assertAlmostEqual(entity_cer["micro"], expected["micro"])
+        for name in (
+            "hits",
+            "substitutions",
+            "deletions",
+            "insertions",
+            "reference_characters",
+        ):
+            self.assertEqual(entity_cer[name], expected[name])
+        self.assertAlmostEqual(report["summary"]["f1"], expected["f1"])
+
+    def test_pier_entity_substitution_has_the_same_selected_span_counts(self):
+        case = self._case("pier", "entity_substitution")
+        report = self._evaluate(case)
+        upstream = case["upstream"]
+
+        self._assert_nlptutti_result(report, case["nlptutti"])
+        self.assertAlmostEqual(
+            report["entity_cer"]["micro"] * 100,
+            upstream["pier_percent"],
+        )
+        for name in ("hits", "substitutions", "deletions", "insertions"):
+            self.assertEqual(report["entity_cer"][name], upstream[name])
+
+    def test_pier_and_nlptutti_exclude_an_insertion_after_the_entity(self):
+        case = self._case("pier", "insertion_outside_entity")
+        report = self._evaluate(case)
+        upstream = case["upstream"]
+
+        self._assert_nlptutti_result(report, case["nlptutti"])
+        self.assertEqual(upstream["rest_insertions"], 1)
+        self.assertAlmostEqual(
+            report["entity_cer"]["micro"] * 100,
+            upstream["pier_percent"],
+        )
+
+    def test_contextasr_exact_entity_contract_matches_nlptutti(self):
+        case = self._case("contextasr_bench", "exact_entity_with_outside_insertion")
+        report = self._evaluate(case)
+        upstream = case["upstream"]
+
+        self._assert_nlptutti_result(report, case["nlptutti"])
+        self.assertAlmostEqual(report["entity_cer"]["micro"], upstream["ne_wer"])
+        self.assertAlmostEqual(1 - report["summary"]["recall"], upstream["ne_fnr"])
+
+    def test_contextasr_word_rate_and_nlptutti_character_rate_stay_distinct(self):
+        case = self._case("contextasr_bench", "fuzzy_entity_misrecognition")
+        report = self._evaluate(case)
+        upstream = case["upstream"]
+
+        self._assert_nlptutti_result(report, case["nlptutti"])
+        self.assertAlmostEqual(upstream["ne_wer"], 1 / upstream["reference_words"])
+        self.assertAlmostEqual(1 - report["summary"]["recall"], upstream["ne_fnr"])
+        self.assertNotAlmostEqual(report["entity_cer"]["micro"], upstream["ne_wer"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- document ContextASR-Bench, NeMo-Skills, Teklia ie-eval, and PIER as related public implementations
- clarify that evaluate_entities is an independent Korean character-span implementation
- add four regression tests backed by outputs captured from pinned upstream commits
- include the upstream fixture in source distributions
- update the Korean changelog and test count

## Why
The existing documentation cited papers but did not point users to executable implementations or clearly separate their contracts from Nlptutti's behavior.

## Validation
- 54 tests passed on Python 3.8 through 3.14
- 54 tests passed after building and reinstalling the source distribution
- build and twine check passed