### PR TITLE
Generalize the STT package description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 모든 중요한 변경 사항은 이 파일에 기록됩니다.
 
 
+## [0.0.0.13] - 2026-07-17
+
+---
+
+### Changed
+- README와 PyPI 설명을 특정 STT 공급자에 종속되지 않는 문구로 수정.
+- 지원 대상 예시는 Microsoft Azure Speech를 먼저 안내하고 Amazon Transcribe, Google Cloud Speech-to-Text, OpenAI Whisper를 함께 명시.
+- PyPI 패키지 요약에 CER, WER, CRR, 키워드, 개체명 평가 범위를 명확히 표시.
+
+---
+
 ## [0.0.0.12] - 2026-07-16
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![Tested Python](https://img.shields.io/badge/tested%20python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue?style=flat-square)](https://github.com/hyeonsangjeon/computing-Korean-STT-error-rates/actions/workflows/test.yml)
 # 한국어 자동 음성 인식 오류율 측정 패키지
 
-Amazon Transcribe와 같은 음성 인식기의 한국어 출력에 대해 문자 오류율(CER), 단어 오류율(WER), 문자 정답률(CRR)을 계산하는 Python 패키지입니다.
+STT(Speech-to-Text) 시스템의 한국어 출력에 대해 문자 오류율(CER), 단어 오류율(WER), 문자 정답률(CRR)을 계산하는 Python 패키지입니다.
+예를 들어 Microsoft의 Azure Speech, Amazon Transcribe, Google Cloud Speech-to-Text 같은 클라우드 서비스와 OpenAI Whisper 같은 음성 인식 모델이 생성한 결과를 같은 기준으로 평가할 수 있습니다.
 정답 문장(reference)과 인식 문장(hypothesis) 사이의 Levenshtein 최소 편집거리에서 치환, 삭제, 삽입 횟수를 계산합니다.
 
 문자 오류율(CER/WER)은 자동 음성 인식 시스템의 성능에 대한 일반적인 메트릭입니다. CER은 WER(단어 오류율)과 유사하지만 단어 대신 문자에 대해 작동합니다. 자세한 내용은 WER 문서를 참조하십시오.[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nlptutti"
-version = "0.0.0.12"
-description = "Korean STT (Speech-to-Text) error rate calculation package"
+version = "0.0.0.13"
+description = "Evaluation metrics for Korean STT outputs, including CER, WER, CRR, keywords, and entities"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [


### PR DESCRIPTION
## 변경 사항
- README 첫 설명을 특정 공급자가 아닌 STT 시스템 전체를 대상으로 수정합니다.
- 예시는 Microsoft의 Azure Speech를 먼저 배치하고 Amazon Transcribe, Google Cloud Speech-to-Text, OpenAI Whisper를 함께 안내합니다.
- PyPI Summary를 공급자 중립적인 평가 범위 설명으로 바꿉니다.
- PyPI 설명 갱신을 위해 버전을 `0.0.0.13`으로 올리고 한국어 변경 이력을 추가합니다.

## 검증
- Python 3.12에서 54개 테스트 통과
- wheel 및 sdist 빌드 성공
- 두 산출물 모두 `twine check` 통과
- wheel 내부 Version, Summary, README 설명 확인
- 독립 환경에서 wheel 설치 및 import 확인