### PR TITLE
Use PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -288,6 +288,7 @@ jobs:
       url: https://pypi.org/project/nlptutti/${{ needs.build.outputs.version }}/
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Download verified distributions
         uses: actions/download-artifact@v8
@@ -298,6 +299,5 @@ jobs:
       - name: Publish verified distributions
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          attestations: false
+          attestations: true
           verbose: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 모든 중요한 변경 사항은 이 파일에 기록됩니다.
 
 
+## [0.0.0.15] - 2026-07-17
+
+---
+
+### Changed
+- PyPI 배포 인증을 장기 API 토큰 방식에서 GitHub Actions OIDC 기반 Trusted Publishing으로 전환.
+- `pypi` environment와 배포 워크플로의 신원을 PyPI 프로젝트에 직접 연결하도록 구성.
+- 배포 산출물에 PyPI 디지털 증명(attestation)을 함께 발행하도록 설정.
+
+### Security
+- 배포 워크플로에서 `PYPI_API_TOKEN` 참조를 제거하고, PyPI 업로드 job에만 단기 OIDC 토큰 발급 권한을 부여.
+- 최초 Trusted Publishing 배포 성공을 확인한 뒤 기존 GitHub Actions 저장소 비밀 값을 제거하도록 전환 절차를 분리.
+
+---
+
 ## [0.0.0.14] - 2026-07-17
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nlptutti"
-version = "0.0.0.14"
+version = "0.0.0.15"
 description = "Evaluation metrics for Korean STT outputs, including CER, WER, CRR, keywords, and entities"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## 변경 사항

- PyPI 배포를 장기 API 토큰에서 GitHub OIDC Trusted Publishing으로 전환
- 배포 산출물 attestation 활성화
- 패키지 버전을 0.0.0.15로 올리고 한국어 변경 이력 추가

## 검증

- Python 3.8~3.14: 버전별 54개 테스트 통과
- Python 3.8~3.14: wheel/sdist 빌드 및 twine check 통과
- Python 3.8~3.14: 빌드 wheel 설치 후 CER/WER 스모크 테스트 통과
- 모든 산출물에서 버전과 README 메타데이터 일치 확인
- actionlint 통과